### PR TITLE
fix: Se re remueve  el prefijo file:/// 

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -264,7 +264,7 @@ Window {
             if (index >= 0 && index < playlistCount) {
                 currentIndex = index
                 player.stop()
-                player.source = "file:///" + playlist[index].url
+                player.source = playlist[index].url
                 player.play()
             }
         }


### PR DESCRIPTION
Se corrige error que no permite reproducir los archivos cargados localmente, porque no los encuentra

```
qt.multimedia.ffmpeg.mediadataholder: Could not open media. FFmpeg error
   description: Invalid argument
   qml: ? Error de reproducción: Could not open file
```
Corrección 

Se re remueve  el prefijo file:/// de player.source para que pueda encontrar la ruta del archivo que se carga